### PR TITLE
Option to link SSL Certs and not copy them

### DIFF
--- a/bin/create_cluster.sh
+++ b/bin/create_cluster.sh
@@ -226,8 +226,11 @@ initialize_db
 printheader "Moving config files to $PGSQL_BASE/etc"
 move_configs
 
-printheader "Copy certificates"
+printheader "Copy certificates if parameter LINK_CERT set to no"
 copy_certs
+
+printheader "Link certificates if parameter LINK_CERT set to yes"
+link_certs
 
 printheader "Updating pg_hba.conf"
 update_pg_hba

--- a/etc/parameters_mycls.conf.tpl
+++ b/etc/parameters_mycls.conf.tpl
@@ -64,6 +64,9 @@ PG_WAL_SEGSIZE=
 # To enable SSL for this cluster or not.
 ENABLE_SSL=no
 
+# Create a Softlink to $PGSQL_BASE/cert/ instead of copy. Only relevant if ENABLE_SSL=yes
+LINK_CERT=no
+
 # The absolute path and filename of the CA certificate for the SSL connections. Relevant if ENABLE_SSL is "yes".
 #   Example:  CA_CERT="/home/user/root.crt"
 CA_CERT=

--- a/lib/shared.lib
+++ b/lib/shared.lib
@@ -172,18 +172,27 @@ chmod 700 $PGSQL_BASE/cert
 
 
 copy_certs() {
-if [[ "$ENABLE_SSL" == "yes" ]]; then
- cp $CA_CERT "$PGSQL_BASE/cert/"
- cp $SERVER_CERT "$PGSQL_BASE/cert/"
- cp $SERVER_KEY "$PGSQL_BASE/cert/"
- chown $OS_USER:$OS_GROUP "$PGSQL_BASE/cert/$(basename $SERVER_CERT)"
- chown $OS_USER:$OS_GROUP "$PGSQL_BASE/cert/$(basename $SERVER_KEY)"
- chown $OS_USER:$OS_GROUP "$PGSQL_BASE/cert/$(basename $CA_CERT)"
- chmod og-rwx "$PGSQL_BASE/cert/$(basename $SERVER_CERT)"
- chmod og-rwx "$PGSQL_BASE/cert/$(basename $SERVER_KEY)"
- chmod og-rwx "$PGSQL_BASE/cert/$(basename $CA_CERT)"
+if [[ "$ENABLE_SSL" == "yes" ]] && [[ "$LINK_CERT" == "no" ]]; then
+   cp $CA_CERT "$PGSQL_BASE/cert/"
+   cp $SERVER_CERT "$PGSQL_BASE/cert/"
+   cp $SERVER_KEY "$PGSQL_BASE/cert/"
+   chown $OS_USER:$OS_GROUP "$PGSQL_BASE/cert/$(basename $SERVER_CERT)"
+   chown $OS_USER:$OS_GROUP "$PGSQL_BASE/cert/$(basename $SERVER_KEY)"
+   chown $OS_USER:$OS_GROUP "$PGSQL_BASE/cert/$(basename $CA_CERT)"
+   chmod og-rwx "$PGSQL_BASE/cert/$(basename $SERVER_CERT)"
+   chmod og-rwx "$PGSQL_BASE/cert/$(basename $SERVER_KEY)"
+   chmod og-rwx "$PGSQL_BASE/cert/$(basename $CA_CERT)"
 fi
 }
+
+link_certs() {
+if [[ "$ENABLE_SSL" == "yes" ]] && [[ "$LINK_CERT" == "yes" ]]; then
+   ln -s $CA_CERT "$PGSQL_BASE/cert/"
+   ln -s $SERVER_CERT "$PGSQL_BASE/cert/"
+   ln -s $SERVER_KEY "$PGSQL_BASE/cert/"
+fi
+}
+
 
 
 


### PR DESCRIPTION
If SSL is enabled and the Cert is host based, we need to link it and not copy it to every cluster.
Added the option LINK_CERT, so that the Certs get only soft linked.